### PR TITLE
filter pattern to find oUF based frames

### DIFF
--- a/LibGetFrame-1.0.lua
+++ b/LibGetFrame-1.0.lua
@@ -25,14 +25,14 @@ local defaultFramePriorities = {
     [9] = "^Grid2Layout", -- grid2
     [10] = "^ElvUF_RaidGroup", -- elv
     [11] = "^oUF_bdGrid", -- bdgrid
-    [12] = "^oUF.*raid", -- generic oUF
+    [12] = "^oUF_.-Raid", -- generic oUF
     [13] = "^LimeGroup", -- lime
     [14] = "^SUFHeaderraid", -- suf
     -- party frames
     [15] = "^AleaUI_GroupHeader", -- Alea
     [16] = "^SUFHeaderparty", --suf
     [17] = "^ElvUF_PartyGroup", -- elv
-    [18] = "^oUF.*party", -- generic oUF
+    [18] = "^oUF_.-Party", -- generic oUF
     [19] = "^PitBull4_Groups_Party", -- pitbull4
     [20] = "^CompactRaid", -- blizz
     [21] = "^CompactParty", -- blizz
@@ -40,7 +40,7 @@ local defaultFramePriorities = {
     [22] = "^SUFUnitplayer",
     [23] = "^PitBull4_Frames_Player",
     [24] = "^ElvUF_Player",
-    [25] = "^oUF.*player",
+    [25] = "^oUF_.-Player",
     [26] = "^PlayerFrame",
 }
 
@@ -48,26 +48,24 @@ local defaultPlayerFrames = {
     "SUFUnitplayer",
     "PitBull4_Frames_Player",
     "ElvUF_Player",
-    "oUF_TukuiPlayer",
-    "PlayerFrame",
-    "oUF_Player",
+    "oUF_.-Player",
     "oUF_PlayerPlate",
+    "PlayerFrame",
 }
 local defaultTargetFrames = {
     "SUFUnittarget",
     "PitBull4_Frames_Target",
     "ElvUF_Target",
+    "oUF_.-Target",
     "TargetFrame",
-    "oUF_TukuiTarget",
-    "oUF_Target",
 }
 local defaultTargettargetFrames = {
     "SUFUnittargetarget",
     "PitBull4_Frames_Target's target",
     "ElvUF_TargetTarget",
-    "TargetTargetFrame",
-    "oUF_TukuiTargetTarget",
+    "oUF_.-TargetTarget",
     "oUF_ToT",
+    "TargetTargetFrame",
 }
 
 local GetFramesCache = {}


### PR DESCRIPTION
Using this pattern will allow us to catch pretty much any frames create with oUF. This removes the need to explicitly test for things like "oUF_TukuiTarget" or "oUF_Target".

Only prerequisite is that the layout creator follows the oUF naming convention: oUF_<style><Unit> i.e: oUF_TukuiTargetTarget.

See: https://github.com/oUF-wow/oUF/blob/master/ouf.lua#L732

The test in action:
https://ideone.com/Sz6AgY

A note about changing ``oUF.*raid`` to ``oUF_.-Raid``.  You could keep ``oUF.*raid``, but I doubt someone uses that. oUF capitalizes raid -> Raid unless the creator explicitly named his frame oUF_raid (with lower-case).

I also opted to include the underscore ``_`` in ``oUF_`` and change ``.*`` to ``.-``.  This is on purpose, as ``.-`` pattern matches as little as possible and this will help fixing another bug? See bellow:
```
local test = "TargetTarget"
test:find("Target") -- this should be false right?
```

If this is not intended then this can fix it:
https://ideone.com/cSgHpa
