### PR TITLE
Fix ATA bug again.

### DIFF
--- a/LibGetFrame-1.0.lua
+++ b/LibGetFrame-1.0.lua
@@ -230,7 +230,8 @@ local defaultOptions = {
     ignoreFrames = {
         "PitBull4_Frames_Target's target's target",
         "ElvUF_PartyGroup%dUnitButton%dTarget",
-        "RavenButton"
+        "RavenButton",
+        "AshToAshUnit%d+ShadowGroupHeaderUnitButton%d+"
     },
     returnAll = false,
 }

--- a/LibGetFrame-1.0.lua
+++ b/LibGetFrame-1.0.lua
@@ -1,5 +1,5 @@
 local MAJOR_VERSION = "LibGetFrame-1.0"
-local MINOR_VERSION = 28
+local MINOR_VERSION = 29
 if not LibStub then error(MAJOR_VERSION .. " requires LibStub.") end
 local lib = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
 if not lib then return end
@@ -30,7 +30,7 @@ local defaultFramePriorities = {
     "^LimeGroup", -- lime
     "^SUFHeaderraid", -- suf
     "^LUFHeaderraid", -- luf
-    "^AshToAsh", -- AshToAsh
+    "^AshToAshUnit%d+Unit%d+", -- AshToAsh
     -- party frames
     "^AleaUI_GroupHeader", -- Alea
     "^SUFHeaderparty", --suf
@@ -82,7 +82,7 @@ local defaultPartyFrames = {
     "^ElvUF_PartyGroup",
     "^oUF_.-Party",
     "^PitBull4_Groups_Party",
-    "^AshToAsh",
+    "^AshToAshUnit%d+Unit%d+",
     "^CompactParty",
 }
 local defaultPartyTargetFrames = {
@@ -101,7 +101,7 @@ local defaultRaidFrames = {
     "^PlexusLayout",
     "^ElvUF_RaidGroup",
     "^oUF_.-Raid",
-    "^AshToAsh",
+    "^AshToAshUnit%d+Unit%d+",
     "^LimeGroup",
     "^SUFHeaderraid",
     "^LUFHeaderraid",

--- a/LibGetFrame-1.0.lua
+++ b/LibGetFrame-1.0.lua
@@ -82,7 +82,6 @@ local defaultPartyFrames = {
     "^ElvUF_PartyGroup",
     "^oUF_.-Party",
     "^PitBull4_Groups_Party",
-    "^AshToAshUnit%d+Unit%d+",
     "^CompactParty",
 }
 local defaultPartyTargetFrames = {
@@ -101,7 +100,7 @@ local defaultRaidFrames = {
     "^PlexusLayout",
     "^ElvUF_RaidGroup",
     "^oUF_.-Raid",
-    "^AshToAshUnit%d+Unit%d+",
+    "^AshToAsh",
     "^LimeGroup",
     "^SUFHeaderraid",
     "^LUFHeaderraid",

--- a/LibGetFrame-1.0.toc
+++ b/LibGetFrame-1.0.toc
@@ -1,4 +1,4 @@
-## Interface: 90100
+## Interface: 90105
 ## Title: Lib: GetFrame
 ## Notes: Get unit frame for a unit
 ## Author: Buds


### PR DESCRIPTION
I am sorry to pull request again. 

By default, ShadowGroupHeader will not be filtered correctly when returnAll=true, this pr has added a default value for it.

Thank you for your patience, and I am sorry for my negligence. Hope this is the last time.