### PR TITLE
add functions to get default settings tables

### DIFF
--- a/LibGetFrame-1.0.lua
+++ b/LibGetFrame-1.0.lua
@@ -57,6 +57,10 @@ local defaultFramePriorities = {
   "^oUF_.-Player",
   "^PlayerFrame",
 }
+local getDefaultFramePriorities = function()
+  return CopyTable(defaultFramePriorities)
+end
+lib.getDefaultFramePriorities = getDefaultFramePriorities
 
 local defaultPlayerFrames = {
   "^InvenUnitFrames_Player",
@@ -68,6 +72,10 @@ local defaultPlayerFrames = {
   "oUF_PlayerPlate",
   "PlayerFrame",
 }
+local getDefaultPlayerFrames = function()
+  return CopyTable(defaultPlayerFrames)
+end
+lib.getDefaultPlayerFrames = getDefaultPlayerFrames
 local defaultTargetFrames = {
   "^InvenUnitFrames_Target",
   "SUFUnittarget",
@@ -77,6 +85,10 @@ local defaultTargetFrames = {
   "oUF_.-Target",
   "TargetFrame",
 }
+local getDefaultTargetFrames = function()
+  return CopyTable(defaultTargetFrames)
+end
+lib.getDefaultTargetFrames = getDefaultTargetFrames
 local defaultTargettargetFrames = {
   "^InvenUnitFrames_TargetTarget",
   "SUFUnittargetarget",
@@ -87,6 +99,10 @@ local defaultTargettargetFrames = {
   "oUF_ToT",
   "TargetTargetFrame",
 }
+local getDefaultTargettargetFrames = function()
+  return CopyTable(defaultTargettargetFrames)
+end
+lib.getDefaultTargettargetFrames = getDefaultTargettargetFrames
 local defaultPartyFrames = {
   "^InvenUnitFrames_Party%d",
   "^AleaUI_GroupHeader",
@@ -97,15 +113,27 @@ local defaultPartyFrames = {
   "^PitBull4_Groups_Party",
   "^CompactParty",
 }
+local getDefaultPartyFrames = function()
+  return CopyTable(defaultPartyFrames)
+end
+lib.getDefaultPartyFrames = getDefaultPartyFrames
 local defaultPartyTargetFrames = {
   "SUFChildpartytarget%d",
 }
+local getDefaultPartyTargetFrames = function()
+  return CopyTable(defaultPartyTargetFrames)
+end
+lib.getDefaultPartyTargetFrames = getDefaultPartyTargetFrames
 local defaultFocusFrames = {
   "^InvenUnitFrames_Focus",
   "ElvUF_FocusTarget",
   "LUFUnitfocus",
   "FocusFrame",
 }
+local getDefaultFocusFrames = function()
+  return CopyTable(defaultFocusFrames)
+end
+lib.getDefaultFocusFrames = getDefaultFocusFrames
 local defaultRaidFrames = {
   "^Vd",
   "^HealBot",
@@ -122,6 +150,10 @@ local defaultRaidFrames = {
   "^LUFHeaderraid",
   "^CompactRaid",
 }
+local getDefaultRaidFrames = function()
+  return CopyTable(defaultRaidFrames)
+end
+lib.getDefaultRaidFrames = getDefaultRaidFrames
 
 --
 local CacheMonitorMixin = {}
@@ -431,6 +463,10 @@ local defaultOptions = {
   },
   returnAll = false,
 }
+local getDefaultOptions = function()
+  return CopyTable(defaultOptions)
+end
+lib.getDefaultOptions = getDefaultOptions
 
 local IterateGroupMembers = function(reversed, forceParty)
   local unit = (not forceParty and IsInRaid()) and 'raid' or 'party'

--- a/LibGetFrame-1.0.lua
+++ b/LibGetFrame-1.0.lua
@@ -1,5 +1,5 @@
 local MAJOR_VERSION = "LibGetFrame-1.0"
-local MINOR_VERSION = 53
+local MINOR_VERSION = 55
 if not LibStub then
   error(MAJOR_VERSION .. " requires LibStub.")
 end


### PR DESCRIPTION
The use case for this is wanting to be able to make adjustments to the settings tables without needing to hardcode them externally. 

For, for example, say I want to set an addon as higher priority, but I also want to include all the other addons in the basic priority list. Instead of hardcoding that table myself, with my adjustments, I would get the table from the lib, adjust as I need to, then use the adjusted table in my calls to the lib. 