### PR TITLE
Make GetUnitFrame return target (etc.) even without additional options

### DIFF
--- a/LibGetFrame-1.0.lua
+++ b/LibGetFrame-1.0.lua
@@ -590,7 +590,11 @@ function lib.GetUnitFrame(target, opt)
   if type(GetFramesCacheListener) ~= "table" then
     Init(true)
   end
-  opt = opt or {}
+  local defaultOpt
+  if not opt then
+	opt = {}
+	defaultOpt = true
+  end
   setmetatable(opt, { __index = defaultOptions })
 
   if not target then
@@ -598,17 +602,17 @@ function lib.GetUnitFrame(target, opt)
   end
 
   local ignoredFrames = CopyTable(opt.ignoreFrames)
-  if opt.ignorePlayerFrame then
+  if opt.ignorePlayerFrame and (not defaultOpt or target ~= "player") then
     for _, v in pairs(opt.playerFrames) do
       tinsert(ignoredFrames, v)
     end
   end
-  if opt.ignoreTargetFrame then
+  if opt.ignoreTargetFrame and (not defaultOpt or target ~= "target") then
     for _, v in pairs(opt.targetFrames) do
       tinsert(ignoredFrames, v)
     end
   end
-  if opt.ignoreTargettargetFrame then
+  if opt.ignoreTargettargetFrame and (not defaultOpt or target ~= "targettarget") then
     for _, v in pairs(opt.targettargetFrames) do
       tinsert(ignoredFrames, v)
     end
@@ -623,7 +627,7 @@ function lib.GetUnitFrame(target, opt)
       tinsert(ignoredFrames, v)
     end
   end
-  if opt.ignoreFocusFrame then
+  if opt.ignoreFocusFrame and (not defaultOpt or target ~= "focus") then
     for _, v in pairs(opt.focusFrames) do
       tinsert(ignoredFrames, v)
     end


### PR DESCRIPTION
Since `defaultOptions` has `ignoreTargetFrame = true` (and so on), calling `GetUnitFrame("target")`, without specifying `ignoreTargetFrame = false` in additional options, returns nothing. Same for player/focus/targettarget.

This is a bit unfortunate and counterintuitive I think, especially for WeakAuras users. When trying to anchor to these frames with the built in "anchored to: unit frames", it simply doesn't work because it calls `GetUnitFrame` without the additional options. This *might* be better fixed on WAs end? But I still think that even outside of WA, I'd like to get my target frame when simply doing `GetUnitFrame("target")`, without the need for `GetUnitFrame("target", {ignoreTargetFrame = true})